### PR TITLE
Add ETCD_IMAGE_TAG & ETCD_IMAGE_URL options for etcd-member.service. Use etcd3 gateway instead of etcd2 proxy.

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -10,3 +10,7 @@ etcd_certs_root: "/etc/ssl/etcd"
 local_certs: "certs"
 
 etcd_core_group: ""
+
+etcd_image_url: "quay.io/coreos/etcd"
+etcd_image_tag: "v3.1.0"
+

--- a/templates/10-peers.conf.j2
+++ b/templates/10-peers.conf.j2
@@ -1,10 +1,12 @@
 {% set proto = "https" if etcd_ca_setup else "http" %}
 {% set my_ip = ansible_default_ipv4.address -%}
 {% set all_etcd = [] -%}
-{% set core_hosts = play_hosts if etcd_core_group == "" else groups[etcd_core_group] %}
+{% set all_etcd_endpoints = [] -%}
+{% set core_hosts = ansible_play_hosts if etcd_core_group == "" else groups[etcd_core_group] %}
 {% for host in core_hosts -%}
   {% set other_ip = hostvars[host]['ansible_default_ipv4']['address'] -%}
   {% set _ = all_etcd.append("%s=%s://%s:2380" % (host, proto, other_ip)) -%}
+  {% set _ = all_etcd_endpoints.append("%s:2379" % (other_ip)) -%}
 {% endfor -%}
 [Service]
 Environment=ETCD_IMAGE_URL={{etcd_image_url}}
@@ -19,5 +21,5 @@ Environment=ETCD_INITIAL_ADVERTISE_PEER_URLS={{proto}}://{{my_ip}}:2380
 Environment=ETCD_LISTEN_PEER_URLS={{proto}}://{{my_ip}}:2380
 Environment=ETCD_ADVERTISE_CLIENT_URLS={{proto}}://{{my_ip}}:2379
 {% else %}
-Environment=ETCD_PROXY=on
+Environment=ETCD_OPTS="gateway start --listen-addr=0.0.0.0:2379 --endpoints={{ all_etcd_endpoints|join(',') }}"
 {% endif %}

--- a/templates/10-peers.conf.j2
+++ b/templates/10-peers.conf.j2
@@ -7,6 +7,8 @@
   {% set _ = all_etcd.append("%s=%s://%s:2380" % (host, proto, other_ip)) -%}
 {% endfor -%}
 [Service]
+Environment=ETCD_IMAGE_URL={{etcd_image_url}}
+Environment=ETCD_IMAGE_TAG={{etcd_image_tag}}
 Environment=ETCD_LISTEN_CLIENT_URLS={{proto}}://0.0.0.0:2379
 Environment=ETCD_INITIAL_CLUSTER={{all_etcd|join(',')}}
 {% if inventory_hostname in core_hosts %}


### PR DESCRIPTION
Add ETCD_IMAGE_TAG & ETCD_IMAGE_URL options for etcd-member.service
    - etcd-member.service is the recommended way to setup etcd (v3 onwards)
      on CoreOS.
    - https://coreos.com/etcd/docs/latest/getting-started-with-etcd.html#setting-up-etcd
       "Container Linux's etcd-member.service systemd unit knows how to fetch
       and run the current etcd v3.x container image, providing etcd v3 without
       requiring the binary to be present in every default OS installation."
    - This change updates 10-peers.conf.j2 to specify etcd version and url using
      ETCD_IMAGE_TAG & ETCD_IMAGE_URL environment variables
      (See /usr/lib/coreos/etcd-wrapper for more details)

Use etcd3 gateway instead of etcd2 proxy    
    - "proxy" supports v2 API only.
      (https://coreos.com/etcd/docs/latest/op-guide/configuration.html#proxy-flags)
    - etcd3 gateway is same as etcd2 proxy
      (https://github.com/coreos/etcd/issues/7439)
    - Updating 10-peers.conf.j2 as per
      https://github.com/coreos/matchbox/blob/master/examples/ignition/etcd3-gateway.yaml