### PR TITLE
etcd upgrade tasks

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -14,3 +14,6 @@ etcd_core_group: ""
 etcd_image_url: "quay.io/coreos/etcd"
 etcd_image_tag: "v3.1.0"
 
+etcd_data_dir: "/var/lib/etcd"
+etcd_backup_tag: ""
+etcd_backup_suffix: ""

--- a/tasks/backup.yml
+++ b/tasks/backup.yml
@@ -1,0 +1,30 @@
+---
+- include_tasks: vars.yml
+
+- name: Check available disk space for etcd backup
+  shell: df --output=avail -k {{ etcd_data_dir }} | tail -n 1
+  register: avail_disk
+
+- name: Check current etcd disk usage
+  become: yes
+  shell: du --exclude='*backup*' -k {{ etcd_data_dir }} | tail -n 1 | cut -f1
+  register: etcd_disk_usage
+
+- name: Abort if insufficient disk space for etcd backup
+  fail:
+    msg: >
+      {{ etcd_disk_usage.stdout|int*2 }} Kb disk space required for etcd backup,
+      {{ avail_disk.stdout }} Kb available.
+  when: etcd_disk_usage.stdout|int*2 > avail_disk.stdout|int
+
+- name: Generate etcd backup (v2 data)
+  become: yes
+  # https://github.com/coreos/etcd/blob/master/Documentation/v2/admin_guide.md#disaster-recovery
+  command: >
+    {{ etcdctl_cmd_v2 }} backup --data-dir={{ etcd_data_dir }} --backup-dir={{ etcd_backup_dir }}
+
+- name: Snapshot the v3 keyspace
+  become: yes
+  # https://github.com/coreos/etcd/blob/master/Documentation/op-guide/maintenance.md#snapshot-backup
+  command: >
+    {{ etcdctl_cmd_v3 }} snapshot save {{ etcd_backup_dir }}/member/snap/db

--- a/tasks/vars.yml
+++ b/tasks/vars.yml
@@ -1,0 +1,28 @@
+---
+# Set etcd backup directory
+- set_fact:
+    backup_dir_name: "etcd-backup-{{ etcd_backup_tag }}{{ etcd_backup_suffix }}"
+
+- set_fact:
+    etcd_backup_dir: "{{ etcd_data_dir }}/{{ backup_dir_name }}"
+
+- name: Get rkt pod list
+  command: rkt list --format=json
+  register: rktlist
+
+- name: Get etcd pod(s)
+  set_fact: etcd_pods="{{ rktlist.stdout | from_json | json_query(etcd_pods_query) }}"
+  vars:
+    etcd_pods_query: "[?state=='running' && contains(app_names, 'etcd')].name"
+
+- fail:
+    msg: "Failed finding a single running etcd pod"
+  when:
+    - etcd_pods|length != 1
+
+- set_fact:
+    etcd_pod_id: "{{ etcd_pods[0] }}"
+
+- set_fact:
+    etcdctl_cmd_v2: "{{ 'rkt enter ' + etcd_pod_id + ' /usr/local/bin/etcdctl' }}"
+    etcdctl_cmd_v3: "{{ 'rkt enter ' + etcd_pod_id + ' /usr/bin/env ETCDCTL_API=3 /usr/local/bin/etcdctl' }}"

--- a/tasks/version.yml
+++ b/tasks/version.yml
@@ -1,0 +1,11 @@
+---
+- include_tasks: vars.yml
+
+- name: Get etcd version
+  become: yes
+  command: >
+    {{ etcdctl_cmd_v2 }} -v
+  register: etcdctl
+
+- set_fact:
+    etcd_version: "{{ etcdctl.stdout | regex_replace('etcdctl version: (.*)\n.*', '\\1') }}"

--- a/templates/10-peers.conf.j2
+++ b/templates/10-peers.conf.j2
@@ -11,6 +11,7 @@
 [Service]
 Environment=ETCD_IMAGE_URL={{etcd_image_url}}
 Environment=ETCD_IMAGE_TAG={{etcd_image_tag}}
+Environment=ETCD_DATA_DIR={{etcd_data_dir}}
 Environment=ETCD_LISTEN_CLIENT_URLS={{proto}}://0.0.0.0:2379
 Environment=ETCD_INITIAL_CLUSTER={{all_etcd|join(',')}}
 {% if inventory_hostname in core_hosts %}


### PR DESCRIPTION
Tasks for backing up etcd (before upgrading etcd)
- Separate task for backing etcd v2 and v3 data

Also includes:
- Helper command to run to etcdctl in v2 and v3 mode (using ETCDCTL_API envvar) inside the rkt pod
- Fact task to get etcd version.