### PR TITLE
Re-design of etcd backups

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 # defaults file for ansible-etcd-cluster
-etcd_service: "etcd2.service"
+etcd_service: "etcd-member.service"
 etcd_dropin_dir: "/etc/systemd/system/{{etcd_service}}.d"
 
 etcd_ca_host: ""
@@ -12,8 +12,13 @@ local_certs: "certs"
 etcd_core_group: ""
 
 etcd_image_url: "quay.io/coreos/etcd"
-etcd_image_tag: "v3.1.0"
+etcd_image_tag: "v3.3.1"
 
 etcd_data_dir: "/var/lib/etcd"
+
 etcd_backup_tag: ""
-etcd_backup_suffix: ""
+etcd_backup_local_root_dir: "/var/lib/etcd/backups"
+etcd_backup_remote_root_dir: "/tmp"
+etcd_backup_node_name: "{{ groups['etcd'][0] }}"
+etcd_backup_keep_local_files: 5
+etcd_backup_keep_remote_files: 5

--- a/tasks/backup.yml
+++ b/tasks/backup.yml
@@ -1,30 +1,128 @@
 ---
 - include_tasks: vars.yml
 
-- name: Check available disk space for etcd backup
-  shell: df --output=avail -k {{ etcd_data_dir }} | tail -n 1
-  register: avail_disk
+- name: Make sure etcd backup local root directory {{ etcd_backup_local_root_dir }} exists and has correct permissions
+  become: yes
+  file:
+    path: "{{ etcd_backup_local_root_dir }}"
+    state: directory
+    owner: etcd
+    group: root
+    mode: 0700
+
+- name: Check available disk space for local etcd backup
+  shell: df --output=avail -k {{ etcd_backup_local_root_dir }} | tail -n 1
+  register: local_avail_disk_space
+
+- name: Check available disk space for remote etcd backup
+  local_action: shell df --output=avail -k {{ etcd_backup_remote_root_dir  }} | tail -n 1
+  register: remote_avail_disk_space
 
 - name: Check current etcd disk usage
   become: yes
-  shell: du --exclude='*backup*' -k {{ etcd_data_dir }} | tail -n 1 | cut -f1
+  shell: du -k {{ etcd_data_dir }}/member | tail -n 1 | cut -f1
   register: etcd_disk_usage
 
-- name: Abort if insufficient disk space for etcd backup
+- name: Abort if insufficient disk space for local etcd backup
   fail:
     msg: >
-      {{ etcd_disk_usage.stdout|int*2 }} Kb disk space required for etcd backup,
-      {{ avail_disk.stdout }} Kb available.
-  when: etcd_disk_usage.stdout|int*2 > avail_disk.stdout|int
+      {{ etcd_disk_usage.stdout | int * 2 }} KB disk space required for local etcd backup, but 
+      {{ local_avail_disk_space.stdout }} KB available.
+  when: (etcd_disk_usage.stdout | int * 2) > (local_avail_disk_space.stdout | int)
 
-- name: Generate etcd backup (v2 data)
-  become: yes
-  # https://github.com/coreos/etcd/blob/master/Documentation/v2/admin_guide.md#disaster-recovery
-  command: >
-    {{ etcdctl_cmd_v2 }} backup --data-dir={{ etcd_data_dir }} --backup-dir={{ etcd_backup_dir }}
+- name: Abort if insufficient disk space for remote etcd backup
+  fail:
+    msg: >
+      {{ etcd_disk_usage.stdout | int * 2 }} KB disk space required for remote etcd backup, but 
+      {{ remote_avail_disk_space.stdout }} KB available.
+  when: (etcd_disk_usage.stdout | int * 2) > (remote_avail_disk_space.stdout | int)
 
-- name: Snapshot the v3 keyspace
+- block:
+    - name: Make sure etcd backup remote directory {{ etcd_backup_remote_dir }} exists and has correct permissions
+      local_action: file
+      args:
+        path: "{{ etcd_backup_remote_dir }}"
+        state: directory
+        mode: 0755
+    
+    - name: Create local etcd backup directory {{ etcd_backup_dir }} and set correct permissions
+      become: yes
+      file:
+        path: "{{ etcd_backup_dir }}"
+        state: directory
+        owner: etcd
+        group: root
+        mode: 0700
+    
+    - name: Create etcd v3 data backup file
+      become: yes
+      # https://coreos.com/etcd/docs/latest/op-guide/recovery.html
+      command: >
+        {{ etcdctl_cmd_v3 }} snapshot save {{ etcd_backup_dir }}/db
+    
+    - name: Archive etcd backup directory {{ etcd_backup_dir }} into a compressed tar.gz file
+      become: yes
+      archive:
+        path: "{{ etcd_backup_dir }}"
+        dest: "{{ etcd_backup_local_root_dir }}/{{ etcd_backup_archive_file }}"
+        owner: etcd
+        group: root
+        mode: 0600
+    
+    - name: Delete no longer needed etcd backup directory {{ etcd_backup_dir }}
+      become: yes
+      file:
+        path: "{{ etcd_backup_dir }}"
+        state: absent
+    
+    - name: Sync etcd backup file {{ etcd_backup_archive_file }} from {{ etcd_backup_node_name }} to localhost
+      become: yes
+      synchronize:
+        mode: pull
+        src: "{{ etcd_backup_local_root_dir }}/{{ etcd_backup_archive_file }}"
+        dest: "{{ etcd_backup_remote_dir }}"
+  when: inventory_hostname == etcd_backup_node_name
+
+- block:
+    - name: Sync etcd backup file {{ etcd_backup_archive_file }} from localhost to all etcd nodes except {{ etcd_backup_node_name }}
+      synchronize:
+        src: "{{ etcd_backup_remote_dir }}/{{ etcd_backup_archive_file }}"
+        dest: "{{ etcd_backup_local_root_dir }}"
+    
+    - name: Fix backup file {{ etcd_backup_archive_file }} ownership on all etcd nodes except {{ etcd_backup_node_name }}
+      file:
+        path: "{{ etcd_backup_local_root_dir }}/{{ etcd_backup_archive_file }}"
+        owner: etcd
+        group: root
   become: yes
-  # https://github.com/coreos/etcd/blob/master/Documentation/op-guide/maintenance.md#snapshot-backup
-  command: >
-    {{ etcdctl_cmd_v3 }} snapshot save {{ etcd_backup_dir }}/member/snap/db
+  when: inventory_hostname != etcd_backup_node_name
+
+- name: Get local backup files list
+  become: yes
+  find:
+    path: "{{ etcd_backup_local_root_dir }}"
+    patterns: '*.tgz'
+  register: local_backup_files
+
+- name: Delete old local backups except for the last {{ etcd_backup_keep_local_files }}
+  become: yes
+  file:
+    path: "{{ item.path }}"
+    state: absent
+  with_items: "{{ (local_backup_files.files | sort(attribute='ctime', reverse=true))[etcd_backup_keep_local_files:] }}"
+
+- block:
+    - name: Get remote backup files list
+      local_action: find
+      args:
+        path: "{{ etcd_backup_remote_dir }}"
+        patterns: '*.tgz'
+      register: remote_backup_files
+    
+    - name: Delete old remote backups except for the last {{ etcd_backup_keep_remote_files }}
+      local_action: file
+      args:
+        path: "{{ item.path }}"
+        state: absent
+      with_items: "{{ (remote_backup_files.files | sort(attribute='ctime', reverse=true))[etcd_backup_keep_remote_files:] }}"
+  when: inventory_hostname == etcd_backup_node_name

--- a/tasks/vars.yml
+++ b/tasks/vars.yml
@@ -1,28 +1,40 @@
 ---
-# Set etcd backup directory
-- set_fact:
-    backup_dir_name: "etcd-backup-{{ etcd_backup_tag }}{{ etcd_backup_suffix }}"
+- name: Set backup_name fact
+  set_fact:
+    backup_name: "{{ inventory_file | basename }}-{{ etcd_backup_node_name.split('.')[0] }}-{{ etcd_backup_tag }}{{ etcd_backup_suffix }}"
 
-- set_fact:
-    etcd_backup_dir: "{{ etcd_data_dir }}/{{ backup_dir_name }}"
+- name: Set etcd_backup_archive_file fact
+  set_fact:
+    etcd_backup_archive_file: "{{ backup_name }}.tgz"
 
-- name: Get rkt pod list
-  command: rkt list --format=json
-  register: rktlist
+- name: Set etcd_backup_remote_dir fact
+  set_fact:
+    etcd_backup_remote_dir: "{{ etcd_backup_remote_root_dir }}/{{ inventory_file | basename }}"
 
-- name: Get etcd pod(s)
-  set_fact: etcd_pods="{{ rktlist.stdout | from_json | json_query(etcd_pods_query) }}"
-  vars:
-    etcd_pods_query: "[?state=='running' && contains(app_names, 'etcd')].name"
+- block:
+    - name: Set etcd_backup_dir fact
+      set_fact:
+        etcd_backup_dir: "{{ etcd_backup_local_root_dir }}/{{ backup_name }}"
 
-- fail:
-    msg: "Failed finding a single running etcd pod"
-  when:
-    - etcd_pods|length != 1
-
-- set_fact:
-    etcd_pod_id: "{{ etcd_pods[0] }}"
-
-- set_fact:
-    etcdctl_cmd_v2: "{{ 'rkt enter ' + etcd_pod_id + ' /usr/local/bin/etcdctl' }}"
-    etcdctl_cmd_v3: "{{ 'rkt enter ' + etcd_pod_id + ' /usr/bin/env ETCDCTL_API=3 /usr/local/bin/etcdctl' }}"
+    - name: Get rkt pod list
+      command: rkt list --format=json
+      register: rktlist
+    
+    - name: Get etcd pod(s)
+      set_fact: etcd_pods="{{ rktlist.stdout | from_json | json_query(etcd_pods_query) }}"
+      vars:
+        etcd_pods_query: "[?state=='running' && contains(app_names, 'etcd')].name"
+    
+    - name: Abort if a single etcd rkt pod is not running
+      fail:
+        msg: "Failed finding a single running etcd pod"
+      when: (etcd_pods | length) != 1
+    
+    - name: Set etcd_pod_id fact
+      set_fact:
+        etcd_pod_id: "{{ etcd_pods[0] }}"
+    
+    - name: Set etcdctl_cmd_v3 fact
+      set_fact:
+        etcdctl_cmd_v3: "{{ 'rkt enter ' + etcd_pod_id + ' /usr/bin/env ETCDCTL_API=3 /usr/local/bin/etcdctl' }}"
+  when: inventory_hostname == etcd_backup_node_name


### PR DESCRIPTION
1. Backup only etcd v3 data, do not backup v2 data.
2. Backup only on one etcd node and distribute the backup to the rest.
3. Store backups in a compressed .tgz format.
4. Use new naming for backup files for better identification.
5. Perform local and remote backups.
6. Manage how many backup files are storred locally and remotely.

Signed-off-by: Alex Romanenko <alex@vmware.com>

```
$ ansible-playbook -i inventory/alex_k8s196_5etcd_new ./playbooks/etcd/backup.yml

PLAY [Backup etcd] **************************************************************************************************************************************************************************************************************************

TASK [Get current date/time in UTC] *********************************************************************************************************************************************************************************************************
changed: [coreos-cluster-1]

TASK [Get actual short hostname of localhost] ***********************************************************************************************************************************************************************************************
changed: [coreos-cluster-1 -> localhost]

TASK [Set etcd_backup_suffix and localhost_actual_hostname facts] ***************************************************************************************************************************************************************************
ok: [coreos-cluster-2]
ok: [coreos-cluster-1]
ok: [coreos-cluster-3]
ok: [coreos-cluster-4]
ok: [coreos-cluster-5]

TASK [Set etcd_backup_remote_root_dir and etcd_backup_keep_remote_files facts if running on DECC Jenkins Slaves] ****************************************************************************************************************************
skipping: [coreos-cluster-1]
skipping: [coreos-cluster-2]
skipping: [coreos-cluster-3]
skipping: [coreos-cluster-4]
skipping: [coreos-cluster-5]

TASK [vmware.etcd-cluster : include_tasks] **************************************************************************************************************************************************************************************************
included: /data/decc/coreos-ansible/roles/vmware.etcd-cluster/tasks/vars.yml for coreos-cluster-1, coreos-cluster-2, coreos-cluster-3, coreos-cluster-4, coreos-cluster-5

TASK [vmware.etcd-cluster : Set backup_name fact] *******************************************************************************************************************************************************************************************
ok: [coreos-cluster-2]
ok: [coreos-cluster-1]
ok: [coreos-cluster-3]
ok: [coreos-cluster-4]
ok: [coreos-cluster-5]

TASK [vmware.etcd-cluster : Set etcd_backup_archive_file fact] ******************************************************************************************************************************************************************************
ok: [coreos-cluster-2]
ok: [coreos-cluster-1]
ok: [coreos-cluster-3]
ok: [coreos-cluster-4]
ok: [coreos-cluster-5]

TASK [vmware.etcd-cluster : Set etcd_backup_remote_dir fact] ********************************************************************************************************************************************************************************
ok: [coreos-cluster-1]
ok: [coreos-cluster-2]
ok: [coreos-cluster-3]
ok: [coreos-cluster-4]
ok: [coreos-cluster-5]

TASK [vmware.etcd-cluster : Set etcd_backup_dir fact] ***************************************************************************************************************************************************************************************
skipping: [coreos-cluster-2]
skipping: [coreos-cluster-3]
skipping: [coreos-cluster-4]
skipping: [coreos-cluster-5]
ok: [coreos-cluster-1]

TASK [vmware.etcd-cluster : Get rkt pod list] ***********************************************************************************************************************************************************************************************
skipping: [coreos-cluster-2]
skipping: [coreos-cluster-4]
skipping: [coreos-cluster-3]
skipping: [coreos-cluster-5]
changed: [coreos-cluster-1]

TASK [vmware.etcd-cluster : Get etcd pod(s)] ************************************************************************************************************************************************************************************************
skipping: [coreos-cluster-2]
skipping: [coreos-cluster-3]
skipping: [coreos-cluster-4]
skipping: [coreos-cluster-5]
ok: [coreos-cluster-1]

TASK [vmware.etcd-cluster : Abort if a single etcd rkt pod is not running] ******************************************************************************************************************************************************************
skipping: [coreos-cluster-1]
skipping: [coreos-cluster-2]
skipping: [coreos-cluster-3]
skipping: [coreos-cluster-4]
skipping: [coreos-cluster-5]

TASK [vmware.etcd-cluster : Set etcd_pod_id fact] *******************************************************************************************************************************************************************************************
skipping: [coreos-cluster-2]
skipping: [coreos-cluster-3]
skipping: [coreos-cluster-4]
skipping: [coreos-cluster-5]
ok: [coreos-cluster-1]

TASK [vmware.etcd-cluster : Set etcdctl_cmd_v3 fact] ****************************************************************************************************************************************************************************************
skipping: [coreos-cluster-2]
skipping: [coreos-cluster-3]
skipping: [coreos-cluster-4]
skipping: [coreos-cluster-5]
ok: [coreos-cluster-1]

TASK [vmware.etcd-cluster : Make sure etcd backup local root directory /var/lib/etcd/backups exists and has correct permissions] ************************************************************************************************************
ok: [coreos-cluster-1]
ok: [coreos-cluster-3]
ok: [coreos-cluster-2]
ok: [coreos-cluster-4]
ok: [coreos-cluster-5]

TASK [vmware.etcd-cluster : Check available disk space for local etcd backup] ***************************************************************************************************************************************************************
changed: [coreos-cluster-3]
changed: [coreos-cluster-1]
changed: [coreos-cluster-2]
changed: [coreos-cluster-4]
changed: [coreos-cluster-5]

TASK [vmware.etcd-cluster : Check available disk space for remote etcd backup] **************************************************************************************************************************************************************
changed: [coreos-cluster-3 -> localhost]
changed: [coreos-cluster-5 -> localhost]
changed: [coreos-cluster-2 -> localhost]
changed: [coreos-cluster-1 -> localhost]
changed: [coreos-cluster-4 -> localhost]

TASK [vmware.etcd-cluster : Check current etcd disk usage] **********************************************************************************************************************************************************************************
changed: [coreos-cluster-3]
changed: [coreos-cluster-4]
changed: [coreos-cluster-1]
changed: [coreos-cluster-2]
changed: [coreos-cluster-5]

TASK [vmware.etcd-cluster : Abort if insufficient disk space for local etcd backup] *********************************************************************************************************************************************************
skipping: [coreos-cluster-1]
skipping: [coreos-cluster-2]
skipping: [coreos-cluster-3]
skipping: [coreos-cluster-4]
skipping: [coreos-cluster-5]

TASK [vmware.etcd-cluster : Abort if insufficient disk space for remote etcd backup] ********************************************************************************************************************************************************
skipping: [coreos-cluster-1]
skipping: [coreos-cluster-2]
skipping: [coreos-cluster-3]
skipping: [coreos-cluster-4]
skipping: [coreos-cluster-5]

TASK [vmware.etcd-cluster : Make sure etcd backup remote directory /tmp/alex_k8s196_5etcd_new exists and has correct permissions] ***********************************************************************************************************
skipping: [coreos-cluster-2]
skipping: [coreos-cluster-3]
skipping: [coreos-cluster-4]
skipping: [coreos-cluster-5]
ok: [coreos-cluster-1 -> localhost]

TASK [vmware.etcd-cluster : Create local etcd backup directory /var/lib/etcd/backups/alex_k8s196_5etcd_new-coreos-cluster-1-20181025185732UTC and set correct permissions] ******************************************************************
skipping: [coreos-cluster-2]
skipping: [coreos-cluster-3]
skipping: [coreos-cluster-4]
skipping: [coreos-cluster-5]
changed: [coreos-cluster-1]

TASK [vmware.etcd-cluster : Create etcd v3 data backup file] ********************************************************************************************************************************************************************************
skipping: [coreos-cluster-2]
skipping: [coreos-cluster-3]
skipping: [coreos-cluster-4]
skipping: [coreos-cluster-5]
changed: [coreos-cluster-1]

TASK [vmware.etcd-cluster : Archive etcd backup directory /var/lib/etcd/backups/alex_k8s196_5etcd_new-coreos-cluster-1-20181025185732UTC into a compressed tar.gz file] *********************************************************************
skipping: [coreos-cluster-2]
skipping: [coreos-cluster-3]
skipping: [coreos-cluster-4]
skipping: [coreos-cluster-5]
changed: [coreos-cluster-1]

TASK [vmware.etcd-cluster : Delete no longer needed etcd backup directory /var/lib/etcd/backups/alex_k8s196_5etcd_new-coreos-cluster-1-20181025185732UTC] ***********************************************************************************
skipping: [coreos-cluster-2]
skipping: [coreos-cluster-3]
skipping: [coreos-cluster-4]
skipping: [coreos-cluster-5]
changed: [coreos-cluster-1]

TASK [vmware.etcd-cluster : Sync etcd backup file alex_k8s196_5etcd_new-coreos-cluster-1-20181025185732UTC.tgz from coreos-cluster-1 to localhost] ******************************************************************************************
skipping: [coreos-cluster-3]
skipping: [coreos-cluster-2]
skipping: [coreos-cluster-4]
skipping: [coreos-cluster-5]
changed: [coreos-cluster-1]

TASK [vmware.etcd-cluster : Sync etcd backup file alex_k8s196_5etcd_new-coreos-cluster-1-20181025185732UTC.tgz from localhost to all etcd nodes except coreos-cluster-1] ********************************************************************
skipping: [coreos-cluster-1]
changed: [coreos-cluster-2]
changed: [coreos-cluster-4]
changed: [coreos-cluster-3]
changed: [coreos-cluster-5]

TASK [vmware.etcd-cluster : Fix backup file alex_k8s196_5etcd_new-coreos-cluster-1-20181025185732UTC.tgz ownership on all etcd nodes except coreos-cluster-1] *******************************************************************************
skipping: [coreos-cluster-1]
changed: [coreos-cluster-2]
changed: [coreos-cluster-3]
changed: [coreos-cluster-4]
changed: [coreos-cluster-5]

TASK [vmware.etcd-cluster : Get local backup files list] ************************************************************************************************************************************************************************************
ok: [coreos-cluster-3]
ok: [coreos-cluster-4]
ok: [coreos-cluster-2]
ok: [coreos-cluster-1]
ok: [coreos-cluster-5]

TASK [vmware.etcd-cluster : Delete old local backups except for the last 5] *****************************************************************************************************************************************************************
changed: [coreos-cluster-3] => (item={u'uid': 232, u'woth': False, u'mtime': 1540492848.3909357, u'inode': 136940, u'isgid': False, u'size': 138511, u'isuid': False, u'isreg': True, u'gid': 0, u'ischr': False, u'wusr': True, u'xoth': False, u'rusr': True, u'nlink': 1, u'issock': False, u'rgrp': False, u'path': u'/var/lib/etcd/backups/alex_k8s196_5etcd_new-coreos-cluster-1-20181025184042UTC.tgz', u'xusr': False, u'atime': 1540492849.8842351, u'isdir': False, u'ctime': 1540492850.3532362, u'isblk': False, u'wgrp': False, u'xgrp': False, u'dev': 2065, u'roth': False, u'isfifo': False, u'mode': u'0600', u'islnk': False})
changed: [coreos-cluster-1] => (item={u'uid': 232, u'woth': False, u'mtime': 1540492848.3909357, u'inode': 262215, u'isgid': False, u'size': 138511, u'isuid': False, u'isreg': True, u'gid': 0, u'ischr': False, u'wusr': True, u'xoth': False, u'rusr': True, u'nlink': 1, u'issock': False, u'rgrp': False, u'path': u'/var/lib/etcd/backups/alex_k8s196_5etcd_new-coreos-cluster-1-20181025184042UTC.tgz', u'xusr': False, u'atime': 1540492849.3339388, u'isdir': False, u'ctime': 1540492848.3909357, u'isblk': False, u'wgrp': False, u'xgrp': False, u'dev': 2065, u'roth': False, u'isfifo': False, u'mode': u'0600', u'islnk': False})
changed: [coreos-cluster-4] => (item={u'uid': 232, u'woth': False, u'mtime': 1540492848.3909357, u'inode': 140669, u'isgid': False, u'size': 138511, u'isuid': False, u'isreg': True, u'gid': 0, u'ischr': False, u'wusr': True, u'xoth': False, u'rusr': True, u'nlink': 1, u'issock': False, u'rgrp': False, u'path': u'/var/lib/etcd/backups/alex_k8s196_5etcd_new-coreos-cluster-1-20181025184042UTC.tgz', u'xusr': False, u'atime': 1540492849.8933573, u'isdir': False, u'ctime': 1540492850.3773587, u'isblk': False, u'wgrp': False, u'xgrp': False, u'dev': 2065, u'roth': False, u'isfifo': False, u'mode': u'0600', u'islnk': False})
changed: [coreos-cluster-2] => (item={u'uid': 232, u'woth': False, u'mtime': 1540492848.3909357, u'inode': 140662, u'isgid': False, u'size': 138511, u'isuid': False, u'isreg': True, u'gid': 0, u'ischr': False, u'wusr': True, u'xoth': False, u'rusr': True, u'nlink': 1, u'issock': False, u'rgrp': False, u'path': u'/var/lib/etcd/backups/alex_k8s196_5etcd_new-coreos-cluster-1-20181025184042UTC.tgz', u'xusr': False, u'atime': 1540492849.8456163, u'isdir': False, u'ctime': 1540492850.3516185, u'isblk': False, u'wgrp': False, u'xgrp': False, u'dev': 2065, u'roth': False, u'isfifo': False, u'mode': u'0600', u'islnk': False})
changed: [coreos-cluster-5] => (item={u'uid': 232, u'woth': False, u'mtime': 1540492848.3909357, u'inode': 262622, u'isgid': False, u'size': 138511, u'isuid': False, u'isreg': True, u'gid': 0, u'ischr': False, u'wusr': True, u'xoth': False, u'rusr': True, u'nlink': 1, u'issock': False, u'rgrp': False, u'path': u'/var/lib/etcd/backups/alex_k8s196_5etcd_new-coreos-cluster-1-20181025184042UTC.tgz', u'xusr': False, u'atime': 1540492849.9577742, u'isdir': False, u'ctime': 1540492850.6247764, u'isblk': False, u'wgrp': False, u'xgrp': False, u'dev': 2065, u'roth': False, u'isfifo': False, u'mode': u'0600', u'islnk': False})

TASK [vmware.etcd-cluster : Get remote backup files list] ***********************************************************************************************************************************************************************************
skipping: [coreos-cluster-2]
skipping: [coreos-cluster-3]
skipping: [coreos-cluster-4]
skipping: [coreos-cluster-5]
ok: [coreos-cluster-1 -> localhost]

TASK [vmware.etcd-cluster : Delete old remote backups except for the last 5] ****************************************************************************************************************************************************************
skipping: [coreos-cluster-2]
skipping: [coreos-cluster-3]
skipping: [coreos-cluster-4]
skipping: [coreos-cluster-5]
changed: [coreos-cluster-1 -> localhost] => (item={u'uid': 5030, u'woth': False, u'mtime': 1540492848.3909357, u'inode': 441728, u'isgid': False, u'size': 138511, u'isuid': False, u'isreg': True, u'gid': 205, u'ischr': False, u'wusr': True, u'xoth': False, u'islnk': False, u'nlink': 1, u'issock': False, u'rgrp': False, u'path': u'/tmp/alex_k8s196_5etcd_new/alex_k8s196_5etcd_new-coreos-cluster-1-20181025184042UTC.tgz', u'xusr': False, u'atime': 1540492849.8370655, u'isdir': False, u'ctime': 1540492849.341059, u'isblk': False, u'wgrp': False, u'xgrp': False, u'dev': 64774, u'roth': False, u'isfifo': False, u'mode': u'0600', u'rusr': True})

PLAY RECAP **********************************************************************************************************************************************************************************************************************************
coreos-cluster-1           : ok=26   changed=13   unreachable=0    failed=0
coreos-cluster-2           : ok=13   changed=6    unreachable=0    failed=0
coreos-cluster-3           : ok=13   changed=6    unreachable=0    failed=0
coreos-cluster-4           : ok=13   changed=6    unreachable=0    failed=0
coreos-cluster-5           : ok=13   changed=6    unreachable=0    failed=0

$ ls -ltha /tmp/alex_k8s196_5etcd_new
total 708K
drwxrwxrwt. 14 root root            4.0K Oct 25 11:57 ..
drwxr-xr-x   2 alex vmware.com_g_qa 4.0K Oct 25 11:57 .
-rw-------   1 alex vmware.com_g_qa 137K Oct 25 11:57 alex_k8s196_5etcd_new-coreos-cluster-1-20181025185732UTC.tgz
-rw-------   1 alex vmware.com_g_qa 138K Oct 25 11:47 alex_k8s196_5etcd_new-coreos-cluster-1-20181025184701UTC.tgz
-rw-------   1 alex vmware.com_g_qa 138K Oct 25 11:46 alex_k8s196_5etcd_new-coreos-cluster-1-20181025184648UTC.tgz
-rw-------   1 alex vmware.com_g_qa 137K Oct 25 11:45 alex_k8s196_5etcd_new-coreos-cluster-1-20181025184515UTC.tgz
-rw-------   1 alex vmware.com_g_qa 137K Oct 25 11:41 alex_k8s196_5etcd_new-coreos-cluster-1-20181025184121UTC.tgz

$ ansible -i inventory/alex_k8s196_5etcd_new etcd -b -m shell -a "ls -ltha /var/lib/etcd/backups"
coreos-cluster-1 | SUCCESS | rc=0 >>
total 708K
drwx------. 2 etcd root 4.0K Oct 25 18:57 .
-rw-------. 1 etcd root 137K Oct 25 18:57 alex_k8s196_5etcd_new-coreos-cluster-1-20181025185732UTC.tgz
-rw-------. 1 etcd root 138K Oct 25 18:47 alex_k8s196_5etcd_new-coreos-cluster-1-20181025184701UTC.tgz
-rw-------. 1 etcd root 138K Oct 25 18:46 alex_k8s196_5etcd_new-coreos-cluster-1-20181025184648UTC.tgz
-rw-------. 1 etcd root 137K Oct 25 18:45 alex_k8s196_5etcd_new-coreos-cluster-1-20181025184515UTC.tgz
-rw-------. 1 etcd root 137K Oct 25 18:41 alex_k8s196_5etcd_new-coreos-cluster-1-20181025184121UTC.tgz
drwxr-xr-x. 4 etcd etcd 4.0K Oct 24 00:56 ..

coreos-cluster-4 | SUCCESS | rc=0 >>
total 708K
drwx------. 2 etcd root 4.0K Oct 25 18:57 .
-rw-------. 1 etcd root 137K Oct 25 18:57 alex_k8s196_5etcd_new-coreos-cluster-1-20181025185732UTC.tgz
-rw-------. 1 etcd root 138K Oct 25 18:47 alex_k8s196_5etcd_new-coreos-cluster-1-20181025184701UTC.tgz
-rw-------. 1 etcd root 138K Oct 25 18:46 alex_k8s196_5etcd_new-coreos-cluster-1-20181025184648UTC.tgz
-rw-------. 1 etcd root 137K Oct 25 18:45 alex_k8s196_5etcd_new-coreos-cluster-1-20181025184515UTC.tgz
-rw-------. 1 etcd root 137K Oct 25 18:41 alex_k8s196_5etcd_new-coreos-cluster-1-20181025184121UTC.tgz
drwxr-xr-x. 4 etcd etcd 4.0K Oct 24 00:56 ..

coreos-cluster-2 | SUCCESS | rc=0 >>
total 708K
drwx------. 2 etcd root 4.0K Oct 25 18:57 .
-rw-------. 1 etcd root 137K Oct 25 18:57 alex_k8s196_5etcd_new-coreos-cluster-1-20181025185732UTC.tgz
-rw-------. 1 etcd root 138K Oct 25 18:47 alex_k8s196_5etcd_new-coreos-cluster-1-20181025184701UTC.tgz
-rw-------. 1 etcd root 138K Oct 25 18:46 alex_k8s196_5etcd_new-coreos-cluster-1-20181025184648UTC.tgz
-rw-------. 1 etcd root 137K Oct 25 18:45 alex_k8s196_5etcd_new-coreos-cluster-1-20181025184515UTC.tgz
-rw-------. 1 etcd root 137K Oct 25 18:41 alex_k8s196_5etcd_new-coreos-cluster-1-20181025184121UTC.tgz
drwxr-xr-x. 4 etcd etcd 4.0K Oct 24 00:56 ..

coreos-cluster-3 | SUCCESS | rc=0 >>
total 708K
drwx------. 2 etcd root 4.0K Oct 25 18:57 .
-rw-------. 1 etcd root 137K Oct 25 18:57 alex_k8s196_5etcd_new-coreos-cluster-1-20181025185732UTC.tgz
-rw-------. 1 etcd root 138K Oct 25 18:47 alex_k8s196_5etcd_new-coreos-cluster-1-20181025184701UTC.tgz
-rw-------. 1 etcd root 138K Oct 25 18:46 alex_k8s196_5etcd_new-coreos-cluster-1-20181025184648UTC.tgz
-rw-------. 1 etcd root 137K Oct 25 18:45 alex_k8s196_5etcd_new-coreos-cluster-1-20181025184515UTC.tgz
-rw-------. 1 etcd root 137K Oct 25 18:41 alex_k8s196_5etcd_new-coreos-cluster-1-20181025184121UTC.tgz
drwxr-xr-x. 4 etcd etcd 4.0K Oct 24 00:56 ..

coreos-cluster-5 | SUCCESS | rc=0 >>
total 708K
drwx------. 2 etcd root 4.0K Oct 25 18:57 .
-rw-------. 1 etcd root 137K Oct 25 18:57 alex_k8s196_5etcd_new-coreos-cluster-1-20181025185732UTC.tgz
-rw-------. 1 etcd root 138K Oct 25 18:47 alex_k8s196_5etcd_new-coreos-cluster-1-20181025184701UTC.tgz
-rw-------. 1 etcd root 138K Oct 25 18:46 alex_k8s196_5etcd_new-coreos-cluster-1-20181025184648UTC.tgz
-rw-------. 1 etcd root 137K Oct 25 18:45 alex_k8s196_5etcd_new-coreos-cluster-1-20181025184515UTC.tgz
-rw-------. 1 etcd root 137K Oct 25 18:41 alex_k8s196_5etcd_new-coreos-cluster-1-20181025184121UTC.tgz
drwxr-xr-x. 4 etcd etcd 4.0K Oct 24 00:56 ..
```