### PR TITLE
Implement etcd v3 cluster restore

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -22,3 +22,5 @@ etcd_backup_remote_root_dir: "/tmp"
 etcd_backup_node_name: "{{ groups['etcd'][0] }}"
 etcd_backup_keep_local_files: 5
 etcd_backup_keep_remote_files: 5
+
+etcd_restore_tmp_dir: "/var/lib/etcd/etcd-restore"

--- a/tasks/restore.yml
+++ b/tasks/restore.yml
@@ -1,0 +1,111 @@
+---
+- name: Stop etcd-member service on all etcd nodes
+  become: yes
+  service: name=etcd-member state=stopped
+
+- name: Get local backup files list
+  become: yes
+  find:
+    path: "{{ etcd_backup_local_root_dir }}"
+    patterns: '*.tgz'
+  register: local_backup_files
+
+- name: Abort if no local etcd backups are found
+  fail:
+    msg: "No local etcd backup files found in {{ etcd_backup_local_root_dir }}"
+  when: local_backup_files.files | length == 0
+
+- name: Set etcd_backup_latest_file fact
+  set_fact:
+    etcd_backup_latest_file: "{{ local_backup_files.files | sort(attribute='mtime', reverse=true) | map(attribute='path') | first }}"
+
+- name: Abort if etcd_backup_latest_file is not the same across all etcd nodes
+  fail:
+    msg: "etcd_backup_latest_file is not the same across all etcd nodes"
+  when: (ansible_play_hosts | map('extract', hostvars, 'etcd_backup_latest_file') | list | unique | length) != 1
+  run_once: true
+
+- name: Check available disk space for etcd restore
+  shell: df --output=avail -k {{ etcd_data_dir }} | tail -n 1
+  register: local_avail_disk_space
+
+- name: Check the uncompressed size of etcd backup
+  become: yes
+  shell: tar tzvf {{ etcd_backup_latest_file }} | awk '{s+=$3} END{print (s/1024)}'
+  register: etcd_backup_uncompressed_size
+
+- name: Abort if insufficient disk space for etcd restore
+  fail:
+    msg: >
+      {{ etcd_backup_uncompressed_size.stdout | int * 3 }} KB disk space required for etcd restore, but
+      {{ local_avail_disk_space.stdout }} KB available.
+  when: (etcd_backup_uncompressed_size.stdout | int * 3) > (local_avail_disk_space.stdout | int)
+
+- name: Unarchive the latest etcd backup file {{ etcd_backup_latest_file }} on each ectd node
+  become: yes
+  unarchive:
+    src: "{{ etcd_backup_latest_file }}"
+    dest: "{{ etcd_backup_local_root_dir }}"
+    remote_src: yes
+
+- name: Set etcd_backup_latest_dir fact
+  set_fact:
+    etcd_backup_latest_dir: "{{ etcd_backup_latest_file.split('.')[0] }}"
+
+- name: Copy etcd v3 restore service file /etc/systemd/system/etcd-restore.service to all etcd nodes
+  become: yes
+  template: src=etcd-restore.service.j2 dest=/etc/systemd/system/etcd-restore.service
+
+- name: Enable and Start etcd v3 restore service on all etcd nodes
+  become: yes
+  service: name=etcd-restore.service enabled=yes daemon_reload=yes state=started
+
+- name: Delete no longer needed unarchived backup directory {{ etcd_backup_latest_dir }}
+  become: yes
+  file:
+    path: "{{ etcd_backup_latest_dir }}"
+    state: absent
+
+- name: Stop and Disable etcd v3 restore service on all etcd nodes
+  become: yes
+  service: name=etcd-restore.service enabled=no daemon_reload=yes state=stopped
+
+- name: Delete no longer needed etcd v3 restore service file /etc/systemd/system/etcd-restore.service on all etcd nodes
+  become: yes
+  file:
+    path: /etc/systemd/system/etcd-restore.service
+    state: absent
+
+- name: Start etcd-member service on all etcd nodes
+  become: yes
+  service: name=etcd-member state=started
+
+- name: Get rkt pod list
+  command: rkt list --format=json
+  register: rktlist
+
+- name: Get etcd pod(s)
+  set_fact: etcd_pods="{{ rktlist.stdout | from_json | json_query(etcd_pods_query) }}"
+  vars:
+    etcd_pods_query: "[?state=='running' && contains(app_names, 'etcd')].name"
+
+- name: Abort if a single etcd rkt pod is not running
+  fail:
+    msg: "Failed finding a single running etcd pod"
+  when: (etcd_pods | length) != 1
+
+- name: Set etcd_pod_id fact
+  set_fact:
+    etcd_pod_id: "{{ etcd_pods[0] }}"
+
+- name: Set etcdctl_cmd_v2 fact
+  set_fact:
+    etcdctl_cmd_v2: "{{ 'rkt enter ' + etcd_pod_id + ' /usr/local/bin/etcdctl' }}"
+
+- name: Pause for 30 seconds to allow etcd cluster to fully come up after the restore
+  pause:
+    seconds: 30
+
+- name: Check etcd cluster health after the restore
+  become: yes
+  command: "{{ etcdctl_cmd_v2 }} cluster-health"

--- a/templates/etcd-restore.service.j2
+++ b/templates/etcd-restore.service.j2
@@ -1,0 +1,40 @@
+{% set proto = "https" if etcd_ca_setup else "http" %}
+{% set my_ip = ansible_default_ipv4.address -%}
+{% set all_etcd = [] -%}
+{% set core_hosts = ansible_play_hosts if etcd_core_group == "" else groups[etcd_core_group] %}
+{% for host in core_hosts -%}
+  {% set other_ip = hostvars[host]['ansible_default_ipv4']['address'] -%}
+  {% set _ = all_etcd.append("%s=%s://%s:2380" % (host, proto, other_ip)) -%}
+{% endfor -%}
+[Unit]
+Description=etcd v3 data restore
+
+[Service]
+Type=oneshot
+
+ExecStartPre=/usr/bin/mkdir -p /var/lib/coreos
+ExecStartPre=-/usr/bin/rkt rm --uuid-file=/var/lib/coreos/etcd-member-wrapper.uuid
+ExecStartPre=/usr/bin/rm -rf {{ etcd_restore_tmp_dir }}
+ExecStart=/usr/lib/coreos/etcd-wrapper $ETCD_OPTS
+ExecStop=-/usr/bin/rkt stop --uuid-file=/var/lib/coreos/etcd-member-wrapper.uuid
+ExecStartPost=/usr/bin/rm -rf {{ etcd_data_dir }}/member
+ExecStartPost=/usr/bin/mv {{ etcd_restore_tmp_dir }}/member {{ etcd_data_dir }}
+ExecStartPost=/usr/bin/chown -R etcd {{ etcd_data_dir }}/member
+ExecStartPost=/usr/bin/rm -rf {{ etcd_restore_tmp_dir }}
+
+Environment=ETCD_IMAGE_URL={{ etcd_image_url }}
+Environment=ETCD_IMAGE_TAG={{ etcd_image_tag }}
+Environment=ETCD_DATA_DIR={{ etcd_data_dir }}
+Environment=ETCD_USER=etcd
+Environment=RKT_RUN_ARGS="--uuid-file-save=/var/lib/coreos/etcd-member-wrapper.uuid"
+Environment=ETCD_IMAGE_ARGS="--insecure-options=image \
+                             --set-env ETCDCTL_API=3 --exec /usr/local/bin/etcdctl -- \
+                             snapshot restore {{ etcd_backup_latest_dir }}/db \
+                             --data-dir={{ etcd_restore_tmp_dir }} \
+                             --name={{ inventory_hostname }} \
+                             --initial-cluster={{ all_etcd | join(',') }} \
+                             --initial-cluster-token=etcd-cluster \
+                             --initial-advertise-peer-urls={{ proto }}://{{ my_ip }}:2380"
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Implement etcd v3 cluster restore

Signed-off-by: Alex Romanenko alex@vmware.com

```
$ ansible-playbook -i inventory/alex_k8s196_5etcd_new ./playbooks/etcd/restore.yml

PLAY [Restore etcd cluster from backup] *****************************************************************************************************************************************************************************************************

TASK [Gathering Facts] **********************************************************************************************************************************************************************************************************************
ok: [coreos-cluster-2]
ok: [coreos-cluster-3]
ok: [coreos-cluster-1]
ok: [coreos-cluster-4]
ok: [coreos-cluster-5]

TASK [vmware.etcd-cluster : Stop etcd-member service on all etcd nodes] *********************************************************************************************************************************************************************
changed: [coreos-cluster-4]
changed: [coreos-cluster-1]
changed: [coreos-cluster-2]
changed: [coreos-cluster-5]
changed: [coreos-cluster-3]

TASK [vmware.etcd-cluster : Get local backup files list] ************************************************************************************************************************************************************************************
ok: [coreos-cluster-1]
ok: [coreos-cluster-3]
ok: [coreos-cluster-2]
ok: [coreos-cluster-4]
ok: [coreos-cluster-5]

TASK [vmware.etcd-cluster : Abort if no local etcd backups are found] ***********************************************************************************************************************************************************************
skipping: [coreos-cluster-1]
skipping: [coreos-cluster-2]
skipping: [coreos-cluster-3]
skipping: [coreos-cluster-4]
skipping: [coreos-cluster-5]

TASK [vmware.etcd-cluster : Set etcd_backup_latest_file fact] *******************************************************************************************************************************************************************************
ok: [coreos-cluster-1]
ok: [coreos-cluster-2]
ok: [coreos-cluster-3]
ok: [coreos-cluster-4]
ok: [coreos-cluster-5]

TASK [vmware.etcd-cluster : Abort if etcd_backup_latest_file is not the same across all etcd nodes] *****************************************************************************************************************************************
skipping: [coreos-cluster-1]

TASK [vmware.etcd-cluster : Check available disk space for etcd restore] ********************************************************************************************************************************************************************
changed: [coreos-cluster-1]
changed: [coreos-cluster-3]
changed: [coreos-cluster-4]
changed: [coreos-cluster-2]
changed: [coreos-cluster-5]

TASK [vmware.etcd-cluster : Check the uncompressed size of etcd backup] *********************************************************************************************************************************************************************
 [WARNING]: Consider using unarchive module rather than running tar

changed: [coreos-cluster-1]
changed: [coreos-cluster-2]
changed: [coreos-cluster-4]
changed: [coreos-cluster-3]
changed: [coreos-cluster-5]

TASK [vmware.etcd-cluster : Abort if insufficient disk space for etcd restore] **************************************************************************************************************************************************************
skipping: [coreos-cluster-1]
skipping: [coreos-cluster-2]
skipping: [coreos-cluster-3]
skipping: [coreos-cluster-4]
skipping: [coreos-cluster-5]

TASK [vmware.etcd-cluster : Unarchive the latest etcd backup file /var/lib/etcd/backups/alex_k8s196_5etcd_new-coreos-cluster-1-20181026213522UTC.tgz on each ectd node] *********************************************************************
changed: [coreos-cluster-2]
changed: [coreos-cluster-4]
changed: [coreos-cluster-3]
changed: [coreos-cluster-1]
changed: [coreos-cluster-5]

TASK [vmware.etcd-cluster : Set etcd_backup_latest_dir fact] ********************************************************************************************************************************************************************************
ok: [coreos-cluster-2]
ok: [coreos-cluster-1]
ok: [coreos-cluster-3]
ok: [coreos-cluster-4]
ok: [coreos-cluster-5]

TASK [vmware.etcd-cluster : Copy etcd v3 restore service file /etc/systemd/system/etcd-restore.service to all etcd nodes] *******************************************************************************************************************
changed: [coreos-cluster-2]
changed: [coreos-cluster-1]
changed: [coreos-cluster-4]
changed: [coreos-cluster-3]
changed: [coreos-cluster-5]

TASK [vmware.etcd-cluster : Enable and Start etcd v3 restore service on all etcd nodes] *****************************************************************************************************************************************************
changed: [coreos-cluster-4]
changed: [coreos-cluster-2]
changed: [coreos-cluster-3]
changed: [coreos-cluster-1]
changed: [coreos-cluster-5]

TASK [vmware.etcd-cluster : Delete no longer needed unarchived backup directory /var/lib/etcd/backups/alex_k8s196_5etcd_new-coreos-cluster-1-20181026213522UTC] *****************************************************************************
changed: [coreos-cluster-2]
changed: [coreos-cluster-4]
changed: [coreos-cluster-1]
changed: [coreos-cluster-3]
changed: [coreos-cluster-5]

TASK [vmware.etcd-cluster : Stop and Disable etcd v3 restore service on all etcd nodes] *****************************************************************************************************************************************************
changed: [coreos-cluster-2]
changed: [coreos-cluster-4]
changed: [coreos-cluster-3]
changed: [coreos-cluster-1]
changed: [coreos-cluster-5]

TASK [vmware.etcd-cluster : Delete no longer needed etcd v3 restore service file /etc/systemd/system/etcd-restore.service on all etcd nodes] ************************************************************************************************
changed: [coreos-cluster-2]
changed: [coreos-cluster-4]
changed: [coreos-cluster-3]
changed: [coreos-cluster-1]
changed: [coreos-cluster-5]

TASK [vmware.etcd-cluster : Start etcd-member service on all etcd nodes] ********************************************************************************************************************************************************************
changed: [coreos-cluster-2]
changed: [coreos-cluster-3]
changed: [coreos-cluster-1]
changed: [coreos-cluster-4]
changed: [coreos-cluster-5]

TASK [vmware.etcd-cluster : Get rkt pod list] ***********************************************************************************************************************************************************************************************
changed: [coreos-cluster-2]
changed: [coreos-cluster-3]
changed: [coreos-cluster-4]
changed: [coreos-cluster-1]
changed: [coreos-cluster-5]

TASK [vmware.etcd-cluster : Get etcd pod(s)] ************************************************************************************************************************************************************************************************
ok: [coreos-cluster-1]
ok: [coreos-cluster-2]
ok: [coreos-cluster-3]
ok: [coreos-cluster-4]
ok: [coreos-cluster-5]

TASK [vmware.etcd-cluster : Abort if a single etcd rkt pod is not running] ******************************************************************************************************************************************************************
skipping: [coreos-cluster-1]
skipping: [coreos-cluster-2]
skipping: [coreos-cluster-3]
skipping: [coreos-cluster-4]
skipping: [coreos-cluster-5]

TASK [vmware.etcd-cluster : Set etcd_pod_id fact] *******************************************************************************************************************************************************************************************
ok: [coreos-cluster-1]
ok: [coreos-cluster-2]
ok: [coreos-cluster-3]
ok: [coreos-cluster-4]
ok: [coreos-cluster-5]

TASK [vmware.etcd-cluster : Set etcdctl_cmd_v2 fact] ****************************************************************************************************************************************************************************************
ok: [coreos-cluster-1]
ok: [coreos-cluster-2]
ok: [coreos-cluster-3]
ok: [coreos-cluster-4]
ok: [coreos-cluster-5]

TASK [vmware.etcd-cluster : Pause for 30 seconds to allow etcd cluster to fully come up after the restore] **********************************************************************************************************************************
Pausing for 30 seconds
(ctrl+C then 'C' = continue early, ctrl+C then 'A' = abort)
ok: [coreos-cluster-1]

TASK [vmware.etcd-cluster : Check etcd cluster health after the restore] ********************************************************************************************************************************************************************
changed: [coreos-cluster-4]
changed: [coreos-cluster-3]
changed: [coreos-cluster-1]
changed: [coreos-cluster-2]
changed: [coreos-cluster-5]

PLAY RECAP **********************************************************************************************************************************************************************************************************************************
coreos-cluster-1           : ok=20   changed=12   unreachable=0    failed=0
coreos-cluster-2           : ok=19   changed=12   unreachable=0    failed=0
coreos-cluster-3           : ok=19   changed=12   unreachable=0    failed=0
coreos-cluster-4           : ok=19   changed=12   unreachable=0    failed=0
coreos-cluster-5           : ok=19   changed=12   unreachable=0    failed=0


$ ansible -i inventory/alex_k8s196_5etcd_new etcd -b -m shell -a "ETCDCTL_API=3 etcdctl get / --prefix --keys-only | wc -l"
coreos-cluster-3 | SUCCESS | rc=0 >>
456

coreos-cluster-2 | SUCCESS | rc=0 >>
456

coreos-cluster-4 | SUCCESS | rc=0 >>
456

coreos-cluster-1 | SUCCESS | rc=0 >>
456

coreos-cluster-5 | SUCCESS | rc=0 >>
456
```