### PR TITLE
Update etcd backup tasks

### DIFF
--- a/tasks/backup.yml
+++ b/tasks/backup.yml
@@ -10,6 +10,28 @@
     group: root
     mode: 0700
 
+- name: Check etcd backup remote root directory {{ etcd_backup_remote_root_dir }}
+  local_action: stat
+  args:
+    path: "{{ etcd_backup_remote_root_dir }}"
+  register: etcd_backup_remote_root_dir_check
+  run_once: true
+
+- name: Abort if etcd backup remote root directory {{ etcd_backup_remote_root_dir }} doesn't exist or is not a directory
+  fail:
+    msg: >
+       {{ etcd_backup_remote_root_dir }} either does not exist or is not a directory.
+  when: (etcd_backup_remote_root_dir_check.stat.exists == false) or
+        (etcd_backup_remote_root_dir_check.stat.isdir == false)
+  run_once: true
+
+- name: Abort if etcd backup remote root directory {{ etcd_backup_remote_root_dir }} is not writeable by the current user
+  fail:
+    msg: >
+      {{ etcd_backup_remote_root_dir }} is not writable by the current user.
+  when: etcd_backup_remote_root_dir_check.stat.writeable == false
+  run_once: true
+
 - name: Check available disk space for local etcd backup
   shell: df --output=avail -k {{ etcd_backup_local_root_dir }} | tail -n 1
   register: local_avail_disk_space
@@ -17,6 +39,7 @@
 - name: Check available disk space for remote etcd backup
   local_action: shell df --output=avail -k {{ etcd_backup_remote_root_dir  }} | tail -n 1
   register: remote_avail_disk_space
+  run_once: true
 
 - name: Check current etcd disk usage
   become: yes
@@ -26,16 +49,17 @@
 - name: Abort if insufficient disk space for local etcd backup
   fail:
     msg: >
-      {{ etcd_disk_usage.stdout | int * 2 }} KB disk space required for local etcd backup, but 
+      {{ etcd_disk_usage.stdout | int * 3 }} KB disk space required for local etcd backup, but 
       {{ local_avail_disk_space.stdout }} KB available.
-  when: (etcd_disk_usage.stdout | int * 2) > (local_avail_disk_space.stdout | int)
+  when: (etcd_disk_usage.stdout | int * 3) > (local_avail_disk_space.stdout | int)
 
 - name: Abort if insufficient disk space for remote etcd backup
   fail:
     msg: >
-      {{ etcd_disk_usage.stdout | int * 2 }} KB disk space required for remote etcd backup, but 
+      {{ etcd_disk_usage.stdout | int * 3 }} KB disk space required for remote etcd backup, but 
       {{ remote_avail_disk_space.stdout }} KB available.
-  when: (etcd_disk_usage.stdout | int * 2) > (remote_avail_disk_space.stdout | int)
+  when: (etcd_disk_usage.stdout | int * 3) > (remote_avail_disk_space.stdout | int)
+  run_once: true
 
 - block:
     - name: Make sure etcd backup remote directory {{ etcd_backup_remote_dir }} exists and has correct permissions
@@ -109,7 +133,7 @@
   file:
     path: "{{ item.path }}"
     state: absent
-  with_items: "{{ (local_backup_files.files | sort(attribute='ctime', reverse=true))[etcd_backup_keep_local_files:] }}"
+  with_items: "{{ (local_backup_files.files | sort(attribute='mtime', reverse=true))[etcd_backup_keep_local_files:] }}"
 
 - block:
     - name: Get remote backup files list
@@ -124,5 +148,5 @@
       args:
         path: "{{ item.path }}"
         state: absent
-      with_items: "{{ (remote_backup_files.files | sort(attribute='ctime', reverse=true))[etcd_backup_keep_remote_files:] }}"
+      with_items: "{{ (remote_backup_files.files | sort(attribute='mtime', reverse=true))[etcd_backup_keep_remote_files:] }}"
   when: inventory_hostname == etcd_backup_node_name


### PR DESCRIPTION
1. Switch backup file cleanup to use mtime vs. ctime to ignore date/time of metadata changes (ownership/permissions) to the backup file.
2. Check etcd backup remote root directory to make sure it exists, an actual directory and writable by the current user.
3. Run the Check/Abort tasks for the available disk space for remote etcd backup only once.
4. Be more conservative about space required for etcd local and remote backups. Require 3x the size of the etcd data file.

Signed-off-by: Alex Romanenko <alex@vmware.com>

```
$ ansible-playbook -i inventory/alex_k8s196_5etcd_new ./playbooks/etcd/backup.yml

PLAY [Backup etcd cluster] ******************************************************************************************************************************************************************************************************************

TASK [Get current date/time in UTC] *********************************************************************************************************************************************************************************************************
changed: [coreos-cluster-1]

TASK [Get actual FQDN hostname of localhost] ************************************************************************************************************************************************************************************************
changed: [coreos-cluster-1 -> localhost]

TASK [Set etcd_backup_suffix, etcd_backup_inventory_group and localhost_actual_hostname facts] **********************************************************************************************************************************************
ok: [coreos-cluster-2]
ok: [coreos-cluster-3]
ok: [coreos-cluster-1]
ok: [coreos-cluster-4]
ok: [coreos-cluster-5]

TASK [Set special etcd_backup_remote_root_dir and etcd_backup_keep_remote_files facts if running on a special etcd backup server] ***********************************************************************************************************
skipping: [coreos-cluster-1]
skipping: [coreos-cluster-2]
skipping: [coreos-cluster-3]
skipping: [coreos-cluster-4]
skipping: [coreos-cluster-5]

TASK [vmware.etcd-cluster : include_tasks] **************************************************************************************************************************************************************************************************
included: /data/decc/coreos-ansible/roles/vmware.etcd-cluster/tasks/vars.yml for coreos-cluster-1, coreos-cluster-2, coreos-cluster-3, coreos-cluster-4, coreos-cluster-5

TASK [vmware.etcd-cluster : Set backup_name fact] *******************************************************************************************************************************************************************************************
ok: [coreos-cluster-2]
ok: [coreos-cluster-1]
ok: [coreos-cluster-3]
ok: [coreos-cluster-4]
ok: [coreos-cluster-5]

TASK [vmware.etcd-cluster : Set etcd_backup_archive_file fact] ******************************************************************************************************************************************************************************
ok: [coreos-cluster-2]
ok: [coreos-cluster-3]
ok: [coreos-cluster-1]
ok: [coreos-cluster-4]
ok: [coreos-cluster-5]

TASK [vmware.etcd-cluster : Set etcd_backup_remote_dir fact] ********************************************************************************************************************************************************************************
ok: [coreos-cluster-2]
ok: [coreos-cluster-1]
ok: [coreos-cluster-3]
ok: [coreos-cluster-4]
ok: [coreos-cluster-5]

TASK [vmware.etcd-cluster : Set etcd_backup_dir fact] ***************************************************************************************************************************************************************************************
skipping: [coreos-cluster-2]
skipping: [coreos-cluster-3]
skipping: [coreos-cluster-4]
skipping: [coreos-cluster-5]
ok: [coreos-cluster-1]

TASK [vmware.etcd-cluster : Get rkt pod list] ***********************************************************************************************************************************************************************************************
skipping: [coreos-cluster-2]
skipping: [coreos-cluster-3]
skipping: [coreos-cluster-4]
skipping: [coreos-cluster-5]
changed: [coreos-cluster-1]

TASK [vmware.etcd-cluster : Get etcd pod(s)] ************************************************************************************************************************************************************************************************
skipping: [coreos-cluster-2]
skipping: [coreos-cluster-3]
skipping: [coreos-cluster-4]
skipping: [coreos-cluster-5]
ok: [coreos-cluster-1]

TASK [vmware.etcd-cluster : Abort if a single etcd rkt pod is not running] ******************************************************************************************************************************************************************
skipping: [coreos-cluster-1]
skipping: [coreos-cluster-2]
skipping: [coreos-cluster-3]
skipping: [coreos-cluster-4]
skipping: [coreos-cluster-5]

TASK [vmware.etcd-cluster : Set etcd_pod_id fact] *******************************************************************************************************************************************************************************************
skipping: [coreos-cluster-2]
skipping: [coreos-cluster-3]
skipping: [coreos-cluster-4]
skipping: [coreos-cluster-5]
ok: [coreos-cluster-1]

TASK [vmware.etcd-cluster : Set etcdctl_cmd_v3 fact] ****************************************************************************************************************************************************************************************
skipping: [coreos-cluster-2]
skipping: [coreos-cluster-3]
skipping: [coreos-cluster-4]
skipping: [coreos-cluster-5]
ok: [coreos-cluster-1]

TASK [vmware.etcd-cluster : Make sure etcd backup local root directory /var/lib/etcd/backups exists and has correct permissions] ************************************************************************************************************
ok: [coreos-cluster-1]
ok: [coreos-cluster-4]
ok: [coreos-cluster-3]
ok: [coreos-cluster-2]
ok: [coreos-cluster-5]

TASK [vmware.etcd-cluster : Check etcd backup remote root directory /tmp] *******************************************************************************************************************************************************************
ok: [coreos-cluster-1 -> localhost]

TASK [vmware.etcd-cluster : Abort if etcd backup remote root directory /tmp doesn't exist or is not a directory] ****************************************************************************************************************************
skipping: [coreos-cluster-1]

TASK [vmware.etcd-cluster : Abort if etcd backup remote root directory /tmp is not writeable by the current user] ***************************************************************************************************************************
skipping: [coreos-cluster-1]

TASK [vmware.etcd-cluster : Check available disk space for local etcd backup] ***************************************************************************************************************************************************************
changed: [coreos-cluster-1]
changed: [coreos-cluster-2]
changed: [coreos-cluster-4]
changed: [coreos-cluster-3]
changed: [coreos-cluster-5]

TASK [vmware.etcd-cluster : Check available disk space for remote etcd backup] **************************************************************************************************************************************************************
changed: [coreos-cluster-1 -> localhost]

TASK [vmware.etcd-cluster : Check current etcd disk usage] **********************************************************************************************************************************************************************************
changed: [coreos-cluster-2]
changed: [coreos-cluster-3]
changed: [coreos-cluster-1]
changed: [coreos-cluster-4]
changed: [coreos-cluster-5]

TASK [vmware.etcd-cluster : Abort if insufficient disk space for local etcd backup] *********************************************************************************************************************************************************
skipping: [coreos-cluster-1]
skipping: [coreos-cluster-2]
skipping: [coreos-cluster-3]
skipping: [coreos-cluster-4]
skipping: [coreos-cluster-5]

TASK [vmware.etcd-cluster : Abort if insufficient disk space for remote etcd backup] ********************************************************************************************************************************************************
skipping: [coreos-cluster-1]

TASK [vmware.etcd-cluster : Make sure etcd backup remote directory /tmp/alex_k8s196_5etcd_new exists and has correct permissions] ***********************************************************************************************************
skipping: [coreos-cluster-2]
skipping: [coreos-cluster-3]
skipping: [coreos-cluster-4]
skipping: [coreos-cluster-5]
ok: [coreos-cluster-1 -> localhost]

TASK [vmware.etcd-cluster : Create local etcd backup directory /var/lib/etcd/backups/alex_k8s196_5etcd_new-coreos-cluster-1-20181030014535UTC and set correct permissions] ******************************************************************
skipping: [coreos-cluster-2]
skipping: [coreos-cluster-3]
skipping: [coreos-cluster-4]
skipping: [coreos-cluster-5]
changed: [coreos-cluster-1]

TASK [vmware.etcd-cluster : Create etcd v3 data backup file] ********************************************************************************************************************************************************************************
skipping: [coreos-cluster-2]
skipping: [coreos-cluster-3]
skipping: [coreos-cluster-4]
skipping: [coreos-cluster-5]
changed: [coreos-cluster-1]

TASK [vmware.etcd-cluster : Archive etcd backup directory /var/lib/etcd/backups/alex_k8s196_5etcd_new-coreos-cluster-1-20181030014535UTC into a compressed tar.gz file] *********************************************************************
skipping: [coreos-cluster-3]
skipping: [coreos-cluster-2]
skipping: [coreos-cluster-4]
skipping: [coreos-cluster-5]
changed: [coreos-cluster-1]

TASK [vmware.etcd-cluster : Delete no longer needed etcd backup directory /var/lib/etcd/backups/alex_k8s196_5etcd_new-coreos-cluster-1-20181030014535UTC] ***********************************************************************************
skipping: [coreos-cluster-2]
skipping: [coreos-cluster-3]
skipping: [coreos-cluster-4]
skipping: [coreos-cluster-5]
changed: [coreos-cluster-1]

TASK [vmware.etcd-cluster : Sync etcd backup file alex_k8s196_5etcd_new-coreos-cluster-1-20181030014535UTC.tgz from coreos-cluster-1 to localhost] ******************************************************************************************
skipping: [coreos-cluster-2]
skipping: [coreos-cluster-3]
skipping: [coreos-cluster-4]
skipping: [coreos-cluster-5]
changed: [coreos-cluster-1]

TASK [vmware.etcd-cluster : Sync etcd backup file alex_k8s196_5etcd_new-coreos-cluster-1-20181030014535UTC.tgz from localhost to all etcd nodes except coreos-cluster-1] ********************************************************************
skipping: [coreos-cluster-1]
changed: [coreos-cluster-3]
changed: [coreos-cluster-4]
changed: [coreos-cluster-2]
changed: [coreos-cluster-5]

TASK [vmware.etcd-cluster : Fix backup file alex_k8s196_5etcd_new-coreos-cluster-1-20181030014535UTC.tgz ownership on all etcd nodes except coreos-cluster-1] *******************************************************************************
skipping: [coreos-cluster-1]
changed: [coreos-cluster-2]
changed: [coreos-cluster-3]
changed: [coreos-cluster-4]
changed: [coreos-cluster-5]

TASK [vmware.etcd-cluster : Get local backup files list] ************************************************************************************************************************************************************************************
ok: [coreos-cluster-4]
ok: [coreos-cluster-2]
ok: [coreos-cluster-1]
ok: [coreos-cluster-3]
ok: [coreos-cluster-5]

TASK [vmware.etcd-cluster : Delete old local backups except for the last 5] *****************************************************************************************************************************************************************
changed: [coreos-cluster-2] => (item={u'uid': 232, u'woth': False, u'mtime': 1540849693.0221992, u'inode': 136541, u'isgid': False, u'size': 116932, u'isuid': False, u'isreg': True, u'gid': 0, u'ischr': False, u'wusr': True, u'xoth': False, u'rusr': True, u'nlink': 1, u'issock': False, u'rgrp': False, u'path': u'/var/lib/etcd/backups/alex_k8s196_5etcd_new-coreos-cluster-1-20181029214806UTC.tgz', u'xusr': False, u'atime': 1540849694.7631447, u'isdir': False, u'ctime': 1540849695.2641468, u'isblk': False, u'wgrp': False, u'xgrp': False, u'dev': 2065, u'roth': False, u'isfifo': False, u'mode': u'0600', u'islnk': False})
changed: [coreos-cluster-4] => (item={u'uid': 232, u'woth': False, u'mtime': 1540849693.0221992, u'inode': 140669, u'isgid': False, u'size': 116932, u'isuid': False, u'isreg': True, u'gid': 0, u'ischr': False, u'wusr': True, u'xoth': False, u'rusr': True, u'nlink': 1, u'issock': False, u'rgrp': False, u'path': u'/var/lib/etcd/backups/alex_k8s196_5etcd_new-coreos-cluster-1-20181029214806UTC.tgz', u'xusr': False, u'atime': 1540849694.7918463, u'isdir': False, u'ctime': 1540849695.2578478, u'isblk': False, u'wgrp': False, u'xgrp': False, u'dev': 2065, u'roth': False, u'isfifo': False, u'mode': u'0600', u'islnk': False})
changed: [coreos-cluster-3] => (item={u'uid': 232, u'woth': False, u'mtime': 1540849693.0221992, u'inode': 136938, u'isgid': False, u'size': 116932, u'isuid': False, u'isreg': True, u'gid': 0, u'ischr': False, u'wusr': True, u'xoth': False, u'rusr': True, u'nlink': 1, u'issock': False, u'rgrp': False, u'path': u'/var/lib/etcd/backups/alex_k8s196_5etcd_new-coreos-cluster-1-20181029214806UTC.tgz', u'xusr': False, u'atime': 1540849694.8203125, u'isdir': False, u'ctime': 1540849695.2533143, u'isblk': False, u'wgrp': False, u'xgrp': False, u'dev': 2065, u'roth': False, u'isfifo': False, u'mode': u'0600', u'islnk': False})
changed: [coreos-cluster-1] => (item={u'uid': 232, u'woth': False, u'mtime': 1540849693.0221992, u'inode': 262231, u'isgid': False, u'size': 116932, u'isuid': False, u'isreg': True, u'gid': 0, u'ischr': False, u'wusr': True, u'xoth': False, u'rusr': True, u'nlink': 1, u'issock': False, u'rgrp': False, u'path': u'/var/lib/etcd/backups/alex_k8s196_5etcd_new-coreos-cluster-1-20181029214806UTC.tgz', u'xusr': False, u'atime': 1540849694.126203, u'isdir': False, u'ctime': 1540849693.0221992, u'isblk': False, u'wgrp': False, u'xgrp': False, u'dev': 2065, u'roth': False, u'isfifo': False, u'mode': u'0600', u'islnk': False})
changed: [coreos-cluster-5] => (item={u'uid': 232, u'woth': False, u'mtime': 1540849693.0221992, u'inode': 262612, u'isgid': False, u'size': 116932, u'isuid': False, u'isreg': True, u'gid': 0, u'ischr': False, u'wusr': True, u'xoth': False, u'rusr': True, u'nlink': 1, u'issock': False, u'rgrp': False, u'path': u'/var/lib/etcd/backups/alex_k8s196_5etcd_new-coreos-cluster-1-20181029214806UTC.tgz', u'xusr': False, u'atime': 1540849694.8726618, u'isdir': False, u'ctime': 1540849695.5316632, u'isblk': False, u'wgrp': False, u'xgrp': False, u'dev': 2065, u'roth': False, u'isfifo': False, u'mode': u'0600', u'islnk': False})

TASK [vmware.etcd-cluster : Get remote backup files list] ***********************************************************************************************************************************************************************************
skipping: [coreos-cluster-2]
skipping: [coreos-cluster-3]
skipping: [coreos-cluster-4]
skipping: [coreos-cluster-5]
ok: [coreos-cluster-1 -> localhost]

TASK [vmware.etcd-cluster : Delete old remote backups except for the last 5] ****************************************************************************************************************************************************************
skipping: [coreos-cluster-2]
skipping: [coreos-cluster-3]
skipping: [coreos-cluster-4]
skipping: [coreos-cluster-5]
changed: [coreos-cluster-1 -> localhost] => (item={u'uid': 5030, u'woth': False, u'mtime': 1540838452.2837136, u'inode': 441731, u'isgid': False, u'size': 112777, u'isuid': False, u'isreg': True, u'gid': 205, u'ischr': False, u'wusr': True, u'xoth': False, u'islnk': False, u'nlink': 1, u'issock': False, u'rgrp': False, u'path': u'/tmp/alex_k8s196_5etcd_new/alex_k8s196_5etcd_new-coreos-cluster-1-20181029184046UTC.tgz', u'xusr': False, u'atime': 1540838454.0356157, u'isdir': False, u'ctime': 1540838453.4346075, u'isblk': False, u'wgrp': False, u'xgrp': False, u'dev': 64774, u'roth': False, u'isfifo': False, u'mode': u'0600', u'rusr': True})

PLAY RECAP **********************************************************************************************************************************************************************************************************************************
coreos-cluster-1           : ok=27   changed=13   unreachable=0    failed=0
coreos-cluster-2           : ok=12   changed=5    unreachable=0    failed=0
coreos-cluster-3           : ok=12   changed=5    unreachable=0    failed=0
coreos-cluster-4           : ok=12   changed=5    unreachable=0    failed=0
coreos-cluster-5           : ok=12   changed=5    unreachable=0    failed=0
```