### PR TITLE
Use different df command options to increase compatibility with different OSes

### DIFF
--- a/tasks/backup.yml
+++ b/tasks/backup.yml
@@ -33,11 +33,11 @@
   run_once: true
 
 - name: Check available disk space for local etcd backup
-  shell: df --output=avail -k {{ etcd_backup_local_root_dir }} | tail -n 1
+  shell: df -Pk {{ etcd_backup_local_root_dir }} | tail -n 1 | awk '{print $4}'
   register: local_avail_disk_space
 
 - name: Check available disk space for remote etcd backup
-  local_action: shell df --output=avail -k {{ etcd_backup_remote_root_dir  }} | tail -n 1
+  local_action: shell df -Pk {{ etcd_backup_remote_root_dir  }} | tail -n 1 | awk '{print $4}'
   register: remote_avail_disk_space
   run_once: true
 

--- a/tasks/restore.yml
+++ b/tasks/restore.yml
@@ -26,7 +26,7 @@
   run_once: true
 
 - name: Check available disk space for etcd restore
-  shell: df --output=avail -k {{ etcd_data_dir }} | tail -n 1
+  shell: df -Pk {{ etcd_data_dir }} | tail -n 1 | awk '{print $4}'
   register: local_avail_disk_space
 
 - name: Check the uncompressed size of etcd backup


### PR DESCRIPTION
Use different df command options to increase compatibility with different OSes.

TESTING DONE:
1. Made sure that new commands work on different versions of CoreOS, CentOS, Ubuntu, and MacOS.
2. Fully ran backup and restore playbooks on my test CentOS 7.5 machine to make sure that everything is still working as expected.