### PR TITLE
Add option to restore from local file on user's machine

### DIFF
--- a/tasks/restore.yml
+++ b/tasks/restore.yml
@@ -1,22 +1,27 @@
 ---
+- name: Abort if there is no enough parameter to get user-defined backup
+  fail:
+    msg: "Require both backup_file_name and backup_file_path to get user-defined backup"
+  when: (backup_file_name is defined and backup_file_path is not defined) or (backup_file_name is not defined and backup_file_path is defined)
+
 - block:
     - name: Sync the user-defined etcd backup file from localhost to all etcd nodes
       synchronize:
         use_ssh_args: yes
-        src: "{{ backup_file_path }}/{{ back_file_name }}"
+        src: "{{ backup_file_path }}/{{ backup_file_name }}"
         dest: "{{ etcd_backup_local_root_dir }}"
     
     - name: Fix file ownership of the user-defined etcd backup file on all etcd nodes
       file:
-        path: "{{ etcd_backup_local_root_dir }}/{{ back_file_name }}"
+        path: "{{ etcd_backup_local_root_dir }}/{{ backup_file_name }}"
         owner: etcd
         group: root
     
     - name: Set etcd_backup_latest_file fact if the user-defined etcd backup file is provided
       set_fact:
-        etcd_backup_latest_file: "{{ etcd_backup_local_root_dir }}/{{ back_file_name }}"
+        etcd_backup_latest_file: "{{ etcd_backup_local_root_dir }}/{{ backup_file_name }}"
   become: yes
-  when: back_file_name is defined and backup_file_path is defined
+  when: backup_file_name is defined and backup_file_path is defined
 
 - block:
     - name: Get local default backup files if no user-defined etcd backup file is provided
@@ -34,8 +39,7 @@
     - name: Set etcd_backup_latest_file fact if no user-defined etcd backup file is provided
       set_fact:
         etcd_backup_latest_file: "{{ local_backup_files.files | sort(attribute='mtime', reverse=true) | map(attribute='path') | first }}"
-
-  when: back_file_name is not defined or backup_file_path is not defined
+  when: backup_file_name is not defined or backup_file_path is not defined
   
 - name: Stop etcd-member service on all etcd nodes
   become: yes

--- a/tasks/restore.yml
+++ b/tasks/restore.yml
@@ -1,47 +1,45 @@
 ---
 - block:
-    - name: Sync etcd backup file {{ restore_file_name }} from localhost to all etcd nodes
+    - name: Sync the user-defined etcd backup file from localhost to all etcd nodes
       synchronize:
         use_ssh_args: yes
-        src: "{{ restore_file_path }}/{{ restore_file_name }}"
+        src: "{{ backup_file_path }}/{{ back_file_name }}"
         dest: "{{ etcd_backup_local_root_dir }}"
     
-    - name: Fix backup file {{ restore_file_name }} ownership on all etcd nodes
+    - name: Fix file ownership of the user-defined etcd backup file on all etcd nodes
       file:
-        path: "{{ etcd_backup_local_root_dir }}/{{ restore_file_name }}"
+        path: "{{ etcd_backup_local_root_dir }}/{{ back_file_name }}"
         owner: etcd
         group: root
+    
+    - name: Set etcd_backup_latest_file fact if the user-defined etcd backup file is provided
+      set_fact:
+        etcd_backup_latest_file: "{{ etcd_backup_local_root_dir }}/{{ back_file_name }}"
   become: yes
-  when: restore_file_name is defined and restore_file_path is defined
+  when: back_file_name is defined and backup_file_path is defined
 
-- name: Set etcd_backup_latest_file fact if using file option
-  set_fact:
-    etcd_backup_latest_file: "{{ etcd_backup_local_root_dir }}/{{ restore_file_name }}"
-  when: restore_file_name is defined and restore_file_path is defined
+- block:
+    - name: Get local default backup files if no user-defined etcd backup file is provided
+      become: yes
+      find:
+        path: "{{ etcd_backup_local_root_dir }}"
+        patterns: '*.tgz'
+      register: local_backup_files
+    
+    - name: Abort if no local default etcd backup files are found
+      fail:
+        msg: "No local default backup files found in {{ etcd_backup_local_root_dir }} and no user-defined etcd backup file is provided"
+      when: local_backup_files.files | length == 0
+    
+    - name: Set etcd_backup_latest_file fact if no user-defined etcd backup file is provided
+      set_fact:
+        etcd_backup_latest_file: "{{ local_backup_files.files | sort(attribute='mtime', reverse=true) | map(attribute='path') | first }}"
 
+  when: back_file_name is not defined or backup_file_path is not defined
+  
 - name: Stop etcd-member service on all etcd nodes
   become: yes
   service: name=etcd-member state=stopped
-
-- name: Get local default backup files if restore file option is not defined
-  become: yes
-  find:
-    path: "{{ etcd_backup_local_root_dir }}"
-    patterns: '*.tgz'
-  register: local_backup_files
-  when: restore_file_name is not defined
-
-- name: Abort if no etcd backups are found
-  fail:
-    msg: "No local backup files found in {{ etcd_backup_local_root_dir }} and no bakcup file option is defined"
-  when:
-    - restore_file_name is not defined or restore_file_path is not defined
-    - local_backup_files.files | length == 0
-
-- name: Set etcd_backup_latest_file fact if using default backup file
-  set_fact:
-    etcd_backup_latest_file: "{{ local_backup_files.files | sort(attribute='mtime', reverse=true) | map(attribute='path') | first }}"
-  when: restore_file_name is not defined
 
 - name: Abort if etcd_backup_latest_file is not the same across all etcd nodes
   fail:

--- a/tasks/restore.yml
+++ b/tasks/restore.yml
@@ -1,23 +1,47 @@
 ---
+- block:
+    - name: Sync etcd backup file {{ restore_file_name }} from localhost to all etcd nodes
+      synchronize:
+        use_ssh_args: yes
+        src: "{{ restore_file_path }}/{{ restore_file_name }}"
+        dest: "{{ etcd_backup_local_root_dir }}"
+    
+    - name: Fix backup file {{ restore_file_name }} ownership on all etcd nodes
+      file:
+        path: "{{ etcd_backup_local_root_dir }}/{{ restore_file_name }}"
+        owner: etcd
+        group: root
+  become: yes
+  when: restore_file_name is defined and restore_file_path is defined
+
+- name: Set etcd_backup_latest_file fact if using file option
+  set_fact:
+    etcd_backup_latest_file: "{{ etcd_backup_local_root_dir }}/{{ restore_file_name }}"
+  when: restore_file_name is defined and restore_file_path is defined
+
 - name: Stop etcd-member service on all etcd nodes
   become: yes
   service: name=etcd-member state=stopped
 
-- name: Get local backup files list
+- name: Get local default backup files if restore file option is not defined
   become: yes
   find:
     path: "{{ etcd_backup_local_root_dir }}"
     patterns: '*.tgz'
   register: local_backup_files
+  when: restore_file_name is not defined
 
-- name: Abort if no local etcd backups are found
+- name: Abort if no etcd backups are found
   fail:
-    msg: "No local etcd backup files found in {{ etcd_backup_local_root_dir }}"
-  when: local_backup_files.files | length == 0
+    msg: "No local backup files found in {{ etcd_backup_local_root_dir }} and no bakcup file option is defined"
+  when:
+    - restore_file_name is not defined or restore_file_path is not defined
+    - local_backup_files.files | length == 0
 
-- name: Set etcd_backup_latest_file fact
+- name: Set etcd_backup_latest_file fact if using default backup file
   set_fact:
     etcd_backup_latest_file: "{{ local_backup_files.files | sort(attribute='mtime', reverse=true) | map(attribute='path') | first }}"
+  when: restore_file_name is not defined
 
 - name: Abort if etcd_backup_latest_file is not the same across all etcd nodes
   fail:


### PR DESCRIPTION
Restore from a user given file. Needs to add parameter `--extra-vars "backup_file_path=/tmp/etcd1 backup_file_name=test.tgz"`.

Please note that the folder name after unzipping the backup tgz file should be the same as the `backup_file_name`. Otherwise, it will fail to restart etcd service. If using user defined backup files, please make sure about it.

```
<AT LOCAL MACHINE>
TASK [vmware.etcd-cluster : Enable and Start etcd v3 restore service on all etcd nodes] ********************************************************************************************************************
fatal: [coreos-cluster-1]: FAILED! => {"changed": false, "msg": "Unable to start service etcd-restore.service: Job for etcd-restore.service failed because the control process exited with error code.\nSee \"systemctl  status etcd-restore.service\" and \"journalctl  -xe\" for details.\n"}
fatal: [coreos-cluster-2]: FAILED! => {"changed": false, "msg": "Unable to start service etcd-restore.service: Job for etcd-restore.service failed because the control process exited with error code.\nSee \"systemctl  status etcd-restore.service\" and \"journalctl  -xe\" for details.\n"}

....

<AT CLUSTER ETCD NODE>
$ systemctl  status etcd-restore.service
● etcd-restore.service - etcd v3 data restore
   Loaded: loaded (/etc/systemd/system/etcd-restore.service; enabled; vendor preset: disabled)
   Active: failed (Result: exit-code) since Wed 2019-06-05 05:36:10 UTC; 1min 7s ago

......

Jun 05 05:36:08 coreos-etcd-01 systemd[1]: Starting etcd v3 data restore...
Jun 05 05:36:09 coreos-etcd-01 etcd-wrapper[95657]: + exec /usr/bin/rkt run --uuid-file-save=/var/lib/
Jun 05 05:36:10 coreos-etcd-01 etcd-wrapper[95657]: Error: open /var/lib/etcd/backups/etcd_test1/db: 
    ^
    |
    |
It expectes the same name
```


Test:
1. The default restore.  `ansible-playbook -vv -i inventory/etcd1 ./playbooks/etcd/restore.yml`
[default.log](https://github.com/vmware/ansible-etcd-cluster/files/3255711/default.log)

2. Restore with user-defined backup files and there is no backup files in etcd node. `ansible-playbook -vv -i inventory/etcd1 ./playbooks/etcd/restore.yml --extra-vars "backup_file_path=/home/jinghuaz/Downloads backup_file_name=etcd_test1.tgz"` 
[user_defined_restore.log](https://github.com/vmware/ansible-etcd-cluster/files/3255716/user_defined_restore.log)

3. Miss parameter `backup_file_name` and it will stop. `ansible-playbook -vv -i inventory/etcd1 ./playbooks/etcd/restore.yml --extra-vars "backup_file_path=/tmp/etcd1"`  
[miss_filename.log](https://github.com/vmware/ansible-etcd-cluster/files/3255720/miss_filename.log)

4. Miss parameter `backup_file_path` and it will stop. `ansible-playbook -vv -i inventory/etcd1 ./playbooks/etcd/restore.yml --extra-vars "backup_file_name=test.tgz"` 
[miss_filepath.log](https://github.com/vmware/ansible-etcd-cluster/files/3255721/miss_filepath.log)

5. Can't find backup file given by the parameter and it will stop. `ansible-playbook -vv -i inventory/etcd1 ./playbooks/etcd/restore.yml --extra-vars "backup_file_path=/error/etcd1 backup_file_name=error.tgz"` 
[not_found.log](https://github.com/vmware/ansible-etcd-cluster/files/3255722/not_found.log)

6. User doesn't provide `backup_file_path` or `backup_file_name` + local backup file on etcd nodes doesn't exist already. It will stop. `ansible-playbook -vv -i inventory/etcd1 ./playbooks/etcd/restore.yml` 
[no_backup.log](https://github.com/vmware/ansible-etcd-cluster/files/3255726/no_backup.log)
