### PR TITLE
Update etcd to version 3.3.13

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -14,7 +14,7 @@ local_certs: "certs"
 etcd_core_group: ""
 
 etcd_image_url: "quay.io/coreos/etcd"
-etcd_image_tag: "v3.3.1"
+etcd_image_tag: "v3.3.13"
 
 etcd_data_dir: "/var/lib/etcd"
 


### PR DESCRIPTION
More details available at https://github.com/etcd-io/etcd/releases/tag/v3.3.13