### PR TITLE
Updated the mode from 0755 to 0775 so a group can write

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -24,5 +24,6 @@ etcd_backup_remote_root_dir: "/tmp"
 etcd_backup_node_name: "{{ groups['etcd'][0] }}"
 etcd_backup_keep_local_files: 5
 etcd_backup_keep_remote_files: 5
+etcd_backup_remote_dir_permission: "0755"
 
 etcd_restore_tmp_dir: "/var/lib/etcd/etcd-restore"

--- a/tasks/backup.yml
+++ b/tasks/backup.yml
@@ -69,7 +69,7 @@
       args:
         path: "{{ etcd_backup_remote_dir }}"
         state: directory
-        mode: 0775
+        mode: "{{ etcd_backup_remote_dir_permission }}"
     
     - name: Create local etcd backup directory {{ etcd_backup_dir }} and set correct permissions
       become: yes

--- a/tasks/backup.yml
+++ b/tasks/backup.yml
@@ -69,7 +69,7 @@
       args:
         path: "{{ etcd_backup_remote_dir }}"
         state: directory
-        mode: 0755
+        mode: 0775
     
     - name: Create local etcd backup directory {{ etcd_backup_dir }} and set correct permissions
       become: yes


### PR DESCRIPTION
As of now, play changes the directory permission to 0755, which is removing group permission to write in the directory. After this change, the group permissions won't be changed.